### PR TITLE
Added rate limit exception

### DIFF
--- a/Anthropic.SDK.Tests/RateLimitTests.cs
+++ b/Anthropic.SDK.Tests/RateLimitTests.cs
@@ -1,0 +1,33 @@
+﻿using Anthropic.SDK.Constants;
+using Anthropic.SDK.Messaging;
+
+namespace Anthropic.SDK.Tests;
+
+[TestClass]
+public class RateLimitTests
+{
+    [TestMethod]
+    public async Task RateLimitTest()
+    {
+        var client = new AnthropicClient();
+        var messages = new List<Message>();
+        messages.Add(new Message(RoleType.User, "Write me a sonnet about the Statue of Liberty"));
+        var parameters = new MessageParameters()
+        {
+            Messages = messages,
+            MaxTokens = 512,
+            Model = AnthropicModels.Claude35Sonnet,
+            Stream = false,
+            Temperature = 1.0m,
+        };
+        var res = await client.Messages.GetClaudeMessageAsync(parameters);
+        Assert.IsNotNull(res.Message.ToString());
+        Assert.IsTrue(res.RateLimits.RequestsLimit > 0);
+        Assert.IsTrue(res.RateLimits.RequestsRemaining > 0);
+        Assert.IsTrue(res.RateLimits.TokensLimit.GetValueOrDefault() > 0);
+        Assert.IsTrue(res.RateLimits.TokensRemaining.GetValueOrDefault() > 0);
+        Assert.IsTrue(res.RateLimits.RequestsReset.HasValue);
+
+    }
+
+}

--- a/Anthropic.SDK/Anthropic.SDK.csproj
+++ b/Anthropic.SDK/Anthropic.SDK.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 	  <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-	  <PackageReference Include="System.Text.Json" Version="6.0.7" />
+	  <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 	<ItemGroup>
 		<None Include="..\README.md">

--- a/Anthropic.SDK/EndpointBase.cs
+++ b/Anthropic.SDK/EndpointBase.cs
@@ -118,39 +118,46 @@ namespace Anthropic.SDK
         private static RateLimits GetRateLimits(HttpResponseMessage message)
         {
             var rateLimits = new RateLimits();
-            if (message.Headers.TryGetValues("anthropic-ratelimit-requests-limit", out var requestsLimit))
+            if (message.Headers.TryGetValues("anthropic-ratelimit-requests-limit", out var requestsLimit)
+                && long.TryParse(requestsLimit.First(), out var parsedRequestsLimit))
             {
-                rateLimits.RequestsLimit = long.Parse(requestsLimit.First());
+                rateLimits.RequestsLimit = parsedRequestsLimit;
             }
 
-            if (message.Headers.TryGetValues("anthropic-ratelimit-requests-remaining", out var requestsRemaining))
+            if (message.Headers.TryGetValues("anthropic-ratelimit-requests-remaining", out var requestsRemaining) &&
+                long.TryParse(requestsRemaining.First(), out var parsedRequestsRemaining))
             {
-                rateLimits.RequestsRemaining = long.Parse(requestsRemaining.First());
+                rateLimits.RequestsRemaining = parsedRequestsRemaining;
             }
 
-            if (message.Headers.TryGetValues("anthropic-ratelimit-requests-reset", out var requestsReset))
+            if (message.Headers.TryGetValues("anthropic-ratelimit-requests-reset", out var requestsReset)
+                && DateTime.TryParse(requestsReset.First(), out var parsedRequestsReset))
             {
-                rateLimits.RequestsReset = DateTime.Parse(requestsReset.First());
+                rateLimits.RequestsReset = parsedRequestsReset;
             }
 
-            if (message.Headers.TryGetValues("anthropic-ratelimit-tokens-limit", out var tokensLimit))
+            if (message.Headers.TryGetValues("anthropic-ratelimit-tokens-limit", out var tokensLimit)
+                && long.TryParse(tokensLimit.First(), out var parsedTokensLimit))
             {
-                rateLimits.TokensLimit = long.Parse(tokensLimit.First());
+                rateLimits.TokensLimit = parsedTokensLimit;
             }
 
-            if (message.Headers.TryGetValues("anthropic-ratelimit-tokens-remaining", out var tokensRemaining))
+            if (message.Headers.TryGetValues("anthropic-ratelimit-tokens-remaining", out var tokensRemaining) &&
+                long.TryParse(tokensRemaining.First(), out var parsedTokensRemaining))
             {
-                rateLimits.TokensRemaining = long.Parse(tokensRemaining.First());
+                rateLimits.TokensRemaining = parsedTokensRemaining;
             }
 
-            if (message.Headers.TryGetValues("anthropic-ratelimit-tokens-reset", out var tokensReset))
+            if (message.Headers.TryGetValues("anthropic-ratelimit-tokens-reset", out var tokensReset)
+                && DateTime.TryParse(tokensReset.First(), out var parsedTokensReset))
             {
-                rateLimits.TokensReset = DateTime.Parse(tokensReset.First());
+                rateLimits.TokensReset = parsedTokensReset;
             }
 
-            if (message.Headers.TryGetValues("retry-after", out var retryAfter))
+            if (message.Headers.TryGetValues("retry-after", out var retryAfter)
+                && long.TryParse(retryAfter.First(), out var parsedRetryAfter))
             {
-                rateLimits.RetryAfter = TimeSpan.FromSeconds(long.Parse(retryAfter.First()));
+                rateLimits.RetryAfter = TimeSpan.FromSeconds(parsedRetryAfter);
             }
 
             return rateLimits;

--- a/Anthropic.SDK/Messaging/MessageResponse.cs
+++ b/Anthropic.SDK/Messaging/MessageResponse.cs
@@ -81,19 +81,17 @@ namespace Anthropic.SDK.Messaging
 
         [JsonPropertyName("usage")]
         public Usage Usage { get; set; }
-
-        
     }
 
     public class RateLimits
     {
-        public long RequestsLimit { get; set; }
-        public long RequestsRemaining { get; set; }
-        public DateTime RequestsReset { get; set; }
-        public long TokensLimit { get; set; }
-        public long TokensRemaining { get; set; }
-        public DateTime TokensReset { get; set; }
-        public long RetryAfter { get; set; }
+        public long? RequestsLimit { get; set; }
+        public long? RequestsRemaining { get; set; }
+        public DateTime? RequestsReset { get; set; }
+        public long? TokensLimit { get; set; }
+        public long? TokensRemaining { get; set; }
+        public DateTime? TokensReset { get; set; }
+        public TimeSpan? RetryAfter { get; set; }
     }
 
 

--- a/Anthropic.SDK/RateLimitsExceeded.cs
+++ b/Anthropic.SDK/RateLimitsExceeded.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using Anthropic.SDK.Messaging;
+
+namespace Anthropic.SDK;
+
+/// <summary>
+/// Thrown when the caller has exhausted current rate limits
+/// The caller should wait until RetryAfter before making another request
+/// </summary>
+public class RateLimitsExceeded : HttpRequestException
+{
+    /// <summary>
+    /// Rate limits as returned by the API
+    /// </summary>
+    public RateLimits RateLimits { get; }
+
+    /// <inheritdoc />
+    public RateLimitsExceeded(string message, RateLimits rateLimits, HttpStatusCode statusCode) :
+#if NET6_0_OR_GREATER
+        base(message, null, statusCode)
+#else
+        base(message)
+#endif
+    {
+        RateLimits = rateLimits;
+    }
+}


### PR DESCRIPTION
# Summary
Added `Anthropic.SDK.RateLimitsExceeded` as a custom exception to allow callers to use rate limit / retry metadata to throttle requests.

This PR also bumps System.Text.Json, as pre 8.0.5 releases have included vulnerabilities