### PR TITLE
Added default ModelId for Messages

### DIFF
--- a/Anthropic.SDK/AnthropicClient.cs
+++ b/Anthropic.SDK/AnthropicClient.cs
@@ -25,6 +25,11 @@ namespace Anthropic.SDK
         /// Version of the Anthropic Beta API
         /// </summary>
         public string AnthropicBetaVersion { get; set; } = "prompt-caching-2024-07-31,message-batches-2024-09-24";
+        
+        /// <summary>
+        /// Model id to use it for the API calls if not specified in request parameters. Default: null
+        /// </summary>
+        public string ModelId { get; set; }
 
         /// <summary>
         /// The API authentication information to use for API calls
@@ -45,14 +50,16 @@ namespace Anthropic.SDK
         /// potentially loading from environment vars.
         /// </param>
         /// <param name="client">A <see cref="HttpClient"/>.</param>
+        /// <param name="modelId">Model id to use it for the API calls if not specified in request parameters</param>
         /// <remarks>
         /// <see cref="AnthropicClient"/> implements <see cref="IDisposable"/> to manage the lifecycle of the resources it uses, including <see cref="HttpClient"/>.
         /// When you initialize <see cref="AnthropicClient"/>, it will create an internal <see cref="HttpClient"/> instance if one is not provided.
         /// This internal HttpClient is disposed of when AnthropicClient is disposed of.
         /// If you provide an external HttpClient instance to AnthropicClient, you are responsible for managing its disposal.
         /// </remarks>
-        public AnthropicClient(APIAuthentication apiKeys = null, HttpClient client = null)
+        public AnthropicClient(APIAuthentication apiKeys = null, HttpClient client = null, string modelId = null)
         {
+            this.ModelId = modelId;
             HttpClient = SetupClient(client);
             this.Auth = apiKeys.ThisOrDefault();
             Messages = new MessagesEndpoint(this);

--- a/Anthropic.SDK/Messaging/MessageParameters.cs
+++ b/Anthropic.SDK/Messaging/MessageParameters.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Anthropic.SDK.Extensions;
 
@@ -42,6 +43,21 @@ namespace Anthropic.SDK.Messaging
         public PromptCacheType PromptCaching { get; set; } = PromptCacheType.None;
         [JsonPropertyName("tool_choice")]
         public ToolChoice ToolChoice { get; set; }
+        
+        /// <summary>
+        /// Creates a shallow copy of the current <see cref="MessageParameters"/> object.
+        /// </summary>
+        /// <returns></returns>
+        public virtual MessageParameters Clone()
+        {
+            var clone = (this.MemberwiseClone() as MessageParameters)!;
+            clone.Messages = [..this.Messages];
+            clone.System = [..this.System];
+            clone.StopSequences = [..this.StopSequences];
+            clone.Tools = [..this.Tools];
+            clone.Metadata = JsonSerializer.Deserialize<dynamic>(JsonSerializer.Serialize(this.Metadata));
+            return clone;
+        }
     }
 
 }

--- a/Anthropic.SDK/Messaging/MessagesEndpoint.ChatClient.cs
+++ b/Anthropic.SDK/Messaging/MessagesEndpoint.ChatClient.cs
@@ -157,7 +157,7 @@ public partial class MessagesEndpoint : IChatClient
     TService IChatClient.GetService<TService>(object key) where TService : class =>
         this as TService;
 
-    private static MessageParameters CreateMessageParameters(IList<ChatMessage> chatMessages, ChatOptions options)
+    private MessageParameters CreateMessageParameters(IList<ChatMessage> chatMessages, ChatOptions options)
     {
         MessageParameters parameters = new();
 
@@ -212,6 +212,8 @@ public partial class MessagesEndpoint : IChatClient
                     .ToList();
             }
         }
+
+        parameters.Model ??= this.Client.ModelId;
 
         foreach (ChatMessage message in chatMessages)
         {

--- a/Anthropic.SDK/Messaging/MessagesEndpoint.cs
+++ b/Anthropic.SDK/Messaging/MessagesEndpoint.cs
@@ -26,6 +26,8 @@ namespace Anthropic.SDK.Messaging
         /// <param name="ctx"></param>
         public async Task<MessageResponse> GetClaudeMessageAsync(MessageParameters parameters, CancellationToken ctx = default)
         {
+            parameters = GetValidatedMessageParameters(parameters);
+
             SetCacheControls(parameters);
 
             parameters.Stream = false;
@@ -50,6 +52,22 @@ namespace Anthropic.SDK.Messaging
             response.ToolCalls = toolCalls;
 
             return response;
+        }
+
+        private MessageParameters GetValidatedMessageParameters(MessageParameters parameters)
+        {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            if (parameters.Model == null)
+            {
+                parameters = parameters.Clone();
+                parameters.Model = Client.ModelId;
+            }
+
+            return parameters;
         }
 
         private static void SetCacheControls(MessageParameters parameters)
@@ -109,6 +127,8 @@ namespace Anthropic.SDK.Messaging
         /// <param name="ctx"></param>
         public async IAsyncEnumerable<MessageResponse> StreamClaudeMessageAsync(MessageParameters parameters, [EnumeratorCancellation] CancellationToken ctx = default)
         {
+            parameters = GetValidatedMessageParameters(parameters);
+            
             SetCacheControls(parameters);
 
             parameters.Stream = true;


### PR DESCRIPTION
This PR added default ModelID to AnthropicClient. 

So if consumer prefer to specify if once with client, not everytime with MessageParameters now has simple way to do this.

PR wont. break or change existing functionallity if consumer won't use new property.The 