### PR TITLE
Fix UsageDetails in streaming responses in IChatClient implementation

### DIFF
--- a/Anthropic.SDK.Tests/Messages.ChatClient.cs
+++ b/Anthropic.SDK.Tests/Messages.ChatClient.cs
@@ -172,14 +172,15 @@ namespace Anthropic.SDK.Tests
                 MaxOutputTokens = 512,
                 Temperature = 1.0f,
             };
+            
+            var chatResponse = await client
+                .GetStreamingResponseAsync("Write a sonnet about the Statue of Liberty. The response must include the word green.", options)
+                .ToChatResponseAsync();
+            
+            Assert.IsTrue(chatResponse.Message.Text!.Contains("green"));
 
-            StringBuilder sb = new();
-            await foreach (var res in client.GetStreamingResponseAsync("Write a sonnet about the Statue of Liberty. The response must include the word green.", options))
-            {
-                sb.Append(res);
-            }
-
-            Assert.IsTrue(sb.ToString().Contains("green") is true, sb.ToString());
+            Assert.IsNotNull(chatResponse.Usage);
+            Assert.IsTrue(chatResponse.Usage.InputTokenCount > 0);
         }
 
         [TestMethod]

--- a/Anthropic.SDK.Tests/Messages.ChatClient.cs
+++ b/Anthropic.SDK.Tests/Messages.ChatClient.cs
@@ -172,14 +172,19 @@ namespace Anthropic.SDK.Tests
                 MaxOutputTokens = 512,
                 Temperature = 1.0f,
             };
-            
-            var chatResponse = await client
-                .GetStreamingResponseAsync("Write a sonnet about the Statue of Liberty. The response must include the word green.", options)
-                .ToChatResponseAsync();
-            
+
+            List<ChatResponseUpdate> updates = new();
+            await foreach (var res in client.GetStreamingResponseAsync("Write a sonnet about the Statue of Liberty. The response must include the word green.", options))
+            {
+                updates.Add(res);
+            }
+
+            var chatResponse = updates.ToChatResponse();
+
             Assert.IsTrue(chatResponse.Message.Text!.Contains("green"));
 
             Assert.IsNotNull(chatResponse.Usage);
+
             Assert.IsTrue(chatResponse.Usage.InputTokenCount > 0);
         }
 

--- a/Anthropic.SDK.Tests/Messages.ChatClient.cs
+++ b/Anthropic.SDK.Tests/Messages.ChatClient.cs
@@ -178,7 +178,9 @@ namespace Anthropic.SDK.Tests
             {
                 updates.Add(res);
             }
-
+            
+            Assert.IsTrue(updates.Last().Contents.OfType<UsageContent>().First().Details.InputTokenCount > 0);
+            
             var chatResponse = updates.ToChatResponse();
 
             Assert.IsTrue(chatResponse.Message.Text!.Contains("green"));

--- a/Anthropic.SDK.Tests/Messages.ChatClient.cs
+++ b/Anthropic.SDK.Tests/Messages.ChatClient.cs
@@ -178,9 +178,7 @@ namespace Anthropic.SDK.Tests
             {
                 updates.Add(res);
             }
-            
-            Assert.IsTrue(updates.Last().Contents.OfType<UsageContent>().First().Details.InputTokenCount > 0);
-            
+
             var chatResponse = updates.ToChatResponse();
 
             Assert.IsTrue(chatResponse.Message.Text!.Contains("green"));

--- a/Anthropic.SDK/Messaging/MessagesEndpoint.ChatClient.cs
+++ b/Anthropic.SDK/Messaging/MessagesEndpoint.ChatClient.cs
@@ -118,7 +118,12 @@ public partial class MessagesEndpoint : IChatClient
             {
                 update.Contents.Add(new SDK.Extensions.MEAI.RedactedThinkingContent(response.ContentBlock?.Data));
             }
-
+            
+            if (response.StreamStartMessage?.Usage is {} startStreamMessageUsage)
+            {
+                update.Contents.Add(new UsageContent(CreateUsageDetails(startStreamMessageUsage)));
+            }
+            
             if (response.Delta is not null)
             {
                 if (!string.IsNullOrEmpty(response.Delta.Text))

--- a/Anthropic.SDK/Messaging/MessagesEndpoint.ChatClient.cs
+++ b/Anthropic.SDK/Messaging/MessagesEndpoint.ChatClient.cs
@@ -83,19 +83,19 @@ public partial class MessagesEndpoint : IChatClient
             },
             ModelId = response.Model,
             RawRepresentation = response,
-            Usage = response.Usage is { } usage ? CreateUsageDetails(usage) : null
+            Usage = response.Usage is { } usage ? CreateUsageDetails(new List<Usage>() { usage }) : null
         };
     }
 
-    private static UsageDetails CreateUsageDetails(Usage usage) => 
+    private static UsageDetails CreateUsageDetails(IList<Usage> usage) => 
         new()
         {
-            InputTokenCount = usage.InputTokens,
-            OutputTokenCount = usage.OutputTokens,
+            InputTokenCount = usage.Select(p => p.InputTokens).Sum(),
+            OutputTokenCount = usage.Select(p => p.OutputTokens).Sum(),
             AdditionalCounts = new()
             {
-                [nameof(usage.CacheCreationInputTokens)] = usage.CacheCreationInputTokens,
-                [nameof(usage.CacheReadInputTokens)] = usage.CacheReadInputTokens,
+                [nameof(Usage.CacheCreationInputTokens)] = usage.Select(p => p.CacheCreationInputTokens).Sum(),
+                [nameof(Usage.CacheReadInputTokens)] = usage.Select(p => p.CacheReadInputTokens).Sum(),
             }
         };
 
@@ -104,6 +104,7 @@ public partial class MessagesEndpoint : IChatClient
         IList<ChatMessage> chatMessages, ChatOptions options, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var thinking = string.Empty;
+        List<Usage> usageBag = new();
         await foreach (MessageResponse response in StreamClaudeMessageAsync(CreateMessageParameters(chatMessages, options), cancellationToken))
         {
             var update = new ChatResponseUpdate
@@ -121,7 +122,7 @@ public partial class MessagesEndpoint : IChatClient
             
             if (response.StreamStartMessage?.Usage is {} startStreamMessageUsage)
             {
-                update.Contents.Add(new UsageContent(CreateUsageDetails(startStreamMessageUsage)));
+                usageBag.Add(startStreamMessageUsage);
             }
             
             if (response.Delta is not null)
@@ -141,6 +142,10 @@ public partial class MessagesEndpoint : IChatClient
                     update.Contents.Add(new Anthropic.SDK.Extensions.MEAI.ThinkingContent(thinking, response.Delta.Signature));
                 }
 
+                if (response.Usage is { } usage)
+                {
+                    usageBag.Add(usage);
+                }
 
                 if (response.Delta?.StopReason is string stopReason)
                 {
@@ -149,12 +154,15 @@ public partial class MessagesEndpoint : IChatClient
                         "max_tokens" => ChatFinishReason.Length,
                         _ => ChatFinishReason.Stop,
                     };
+
+                    if (usageBag.Any())
+                    {
+                        update.Contents.Add(new UsageContent(CreateUsageDetails(usageBag)));
+                    }
+
                 }
 
-                if (response.Usage is { } usage)
-                {
-                    update.Contents.Add(new UsageContent(CreateUsageDetails(usage)));
-                }
+                
             }
 
             if (response.ToolCalls is { Count: > 0 })
@@ -168,6 +176,7 @@ public partial class MessagesEndpoint : IChatClient
 
             yield return update;
         }
+
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Anthropic sends usage details multiple times, and as a client you're on the hook for adding them together.
pretty unfriendly if you ask me, but here we are.  It also sends the first usage_details in an easy to miss place, which was missed, and was input tokens for all streaming requests to always be reported as 0.

I augmented the existing streaming test with an extra assertion, since they're integrationtests and kind of expensive. let me know if you'd rather have a unique test.

cc @stephentoub 