### PR TITLE
Fix bug with multiple tool calls overwriting each other

### DIFF
--- a/Anthropic.SDK/Messaging/MessagesEndpoint.cs
+++ b/Anthropic.SDK/Messaging/MessagesEndpoint.cs
@@ -38,12 +38,14 @@ namespace Anthropic.SDK.Messaging
                 if (message.Type == ContentType.tool_use)
                 {
                     var tool = parameters.Tools?.FirstOrDefault(t => t.Function.Name == (message as ToolUseContent).Name);
-                    
+
                     if (tool != null)
                     {
-                        tool.Function.Arguments = (message as ToolUseContent).Input;
-                        tool.Function.Id = (message as ToolUseContent).Id;
-                        toolCalls.Add(tool.Function);
+                        var copiedTool = new Common.Tool(tool);
+                        copiedTool.Function.Arguments = (message as ToolUseContent).Input;
+                        copiedTool.Function.Id = (message as ToolUseContent).Id;
+
+                        toolCalls.Add(copiedTool.Function);
                     }
                 }
             }
@@ -117,9 +119,11 @@ namespace Anthropic.SDK.Messaging
 
                     if (tool != null)
                     {
-                        tool.Function.Arguments = arguments;
-                        tool.Function.Id = id;
-                        toolCalls.Add(tool.Function);
+                        var copiedTool = new Common.Tool(tool);
+                        copiedTool.Function.Arguments = arguments;
+                        copiedTool.Function.Id = id;
+
+                        toolCalls.Add(copiedTool.Function);
                     }
                     captureTool = false;
                     result.ToolCalls = toolCalls;


### PR DESCRIPTION
## Summary
Fixes a bug where multiple tool calls to the same function in a single response would overwrite each other's IDs and arguments.

## Problem
When the model called the same tool multiple times in one response, the code was reusing the same tool instance and directly modifying its properties:
```csharp
tool.Function.Arguments = (message as ToolUseContent).Input;
tool.Function.Id = (message as ToolUseContent).Id;
```
This caused all tool calls to end up with the same ID and arguments (the last ones processed).

## Solution
- Create a copy of the tool for each call using `new Common.Tool(tool)` 
- Set the arguments and ID on the copied instance instead of the original
- Applied fix to both non-streaming (`GetClaudeMessageAsync`) and streaming (`StreamClaudeMessageAsync`) methods

## Test
Added `TestMultipleCallsSameFunction` that:
- Asks Claude to make multiple calls to the same function in one response
- Verifies each tool call has a unique ID using `HashSet.Add()`
- Verifies each tool call has different arguments by comparing JSON strings
- Test fails before the fix and passes after the fix

## Files Changed
- `Anthropic.SDK/Messaging/MessagesEndpoint.cs` - The bug fix
- `Anthropic.SDK.Tests/Tools.cs` - Added test case

🤖 Generated with [Claude Code](https://claude.ai/code)