### PR TITLE
Update SK samples and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,14 @@ Option 2:
 ```csharp
 using Microsoft.SemanticKernel;
 
-var skChatService =
-    new ChatClientBuilder(new AnthropicClient().Messages)
+IChatClient CreateChatClient(IServiceProvider _)
+    => new ChatClientBuilder(new AnthropicClient().Messages)
         .UseFunctionInvocation()
-        .Build()
-        .AsChatCompletionService();
-
+        .Build();
 
 var sk = Kernel.CreateBuilder();
 sk.Plugins.AddFromType<SkPlugins>("Weather");
-sk.Services.AddSingleton<IChatCompletionService>(skChatService);
+sk.Services.AddSingleton(CreateChatClient);
 ```
 See integration tests for a more complete example.
 


### PR DESCRIPTION
Semantic Kernel now supports natively the `Microsoft.Extensions.AI` types and this pull request refactors the `SemanticKernel` examples and documentation reflecting that change moving forward as the ideal approach.

### Refactoring and Test Improvements:
* Replaced `IChatCompletionService` with `IChatClient` in `TestSKInit`, simplifying the service creation process and aligning with modern patterns. Updated the test logic to reflect this change.

### Plugin Optimization:
* Updated the `GetWeather` method in the `SkPlugins` class to return a completed `Task` directly, improving performance by avoiding unnecessary `async`/`await` overhead.

### Documentation Alignment:
* Updated the example in the `README.md` to use the new `IChatClient` creation pattern, ensuring consistency with the refactored code.