### PR TITLE
fix: invalid ttl for cache control on vertex ai

### DIFF
--- a/Anthropic.SDK/Messaging/CacheControl.cs
+++ b/Anthropic.SDK/Messaging/CacheControl.cs
@@ -13,7 +13,7 @@ public class CacheControl
     /// </summary>
     [JsonPropertyName("ttl")]
     [JsonConverter(typeof(CacheDurationConverter))]
-    public CacheDuration TTL { get; set; }
+    public CacheDuration? TTL { get; set; }
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/Anthropic.SDK/Messaging/CacheDurationConverter.cs
+++ b/Anthropic.SDK/Messaging/CacheDurationConverter.cs
@@ -7,24 +7,30 @@ namespace Anthropic.SDK.Messaging;
 public enum CacheDuration
 {
     FiveMinutes,
-    OneHour
+    OneHour,
 }
 
-public class CacheDurationConverter : JsonConverter<CacheDuration>
+public class CacheDurationConverter : JsonConverter<CacheDuration?>
 {
-    public override CacheDuration Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override CacheDuration? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         string? value = reader.GetString();
         return value switch
         {
+            null => null,
             "5m" => CacheDuration.FiveMinutes,
             "1h" => CacheDuration.OneHour,
             _ => throw new JsonException($"Invalid cache duration: {value}")
         };
     }
 
-    public override void Write(Utf8JsonWriter writer, CacheDuration value, JsonSerializerOptions options)
+   public override void Write(Utf8JsonWriter writer, CacheDuration? value, JsonSerializerOptions options)
     {
+        if (value is null)
+        {
+            return;
+        }
+
         string str = value switch
         {
             CacheDuration.FiveMinutes => "5m",


### PR DESCRIPTION
After upgrading to v5.7.1, any request I make using `VertexAIClient` with caching enabled fails with a bad request error, given that TTL is not a valid field in the request. 

The change in this PR makes the property nullable and omits it from the serialization when null.