### PR TITLE
Fix Parallel tool calls, and added setting to disable it if needed

### DIFF
--- a/Anthropic.SDK/Messaging/MessagesEndpoint.cs
+++ b/Anthropic.SDK/Messaging/MessagesEndpoint.cs
@@ -120,7 +120,8 @@ namespace Anthropic.SDK.Messaging
                     arguments += result.Delta.PartialJson;
                 }
 
-                if (captureTool && result.Delta?.StopReason == "tool_use")
+                // Finalize tool when content_block_stop is received (supports multiple parallel tool calls)
+                if (captureTool && result.Type == "content_block_stop")
                 {
                     var tool = parameters.Tools?.FirstOrDefault(t => t.Function.Name == name);
 
@@ -133,6 +134,11 @@ namespace Anthropic.SDK.Messaging
                         toolCalls.Add(copiedTool.Function);
                     }
                     captureTool = false;
+                }
+                
+                // Always set ToolCalls on result (accumulates across stream)
+                if (toolCalls.Count > 0)
+                {
                     result.ToolCalls = toolCalls;
                 }
                 

--- a/Anthropic.SDK/Messaging/ToolChoice.cs
+++ b/Anthropic.SDK/Messaging/ToolChoice.cs
@@ -13,5 +13,7 @@ namespace Anthropic.SDK.Messaging
         public ToolChoiceType Type { get; set; } = ToolChoiceType.Auto;
         [JsonPropertyName("name")]
         public string Name { get; set; }
+        [JsonPropertyName("disable_parallel_tool_use")]
+        public bool? DisableParallelToolUse { get; set; }
     }
 }


### PR DESCRIPTION
Parallel tool calls wasn't working because it finalized on first tool_use, resulting in only one tool call even though AI is trying to invoke multiple. and then also added the proper setting to ToolChoice to disable it.

--

Modified `MessagesEndpoint.cs` to improve tool handling:
- Finalize tools on `content_block_stop` events to support parallel tool calls.
- Ensure `ToolCalls` are accumulated across the stream.
- Reset `captureTool` after finalizing a tool.

Added `DisableParallelToolUse` property to `ToolChoice.cs`:
- Allows configuration to disable parallel tool usage for specific tools.