### PR TITLE
Fix complex tool result mapping when using Microsoft.Extensions.AI

### DIFF
--- a/Anthropic.SDK/Messaging/ChatClientHelper.cs
+++ b/Anthropic.SDK/Messaging/ChatClientHelper.cs
@@ -170,10 +170,67 @@ namespace Anthropic.SDK.Messaging
                         switch (content)
                         {
                             case Microsoft.Extensions.AI.FunctionResultContent frc:
+                                var toolResultContent = new List<ContentBase>();
+                                
+                                // Handle different result types
+                                if (frc.Result is string stringResult)
+                                {
+                                    // Simple string result
+                                    toolResultContent.Add(new TextContent() { Text = stringResult });
+                                }
+                                else if (frc.Result is JsonElement jsonElement && jsonElement.ValueKind == JsonValueKind.Object)
+                                {
+                                    // Check if it's a content array structure
+                                    if (jsonElement.TryGetProperty("content", out JsonElement contentArray) && 
+                                        contentArray.ValueKind == JsonValueKind.Array)
+                                    {
+                                        foreach (JsonElement item in contentArray.EnumerateArray())
+                                        {
+                                            if (item.TryGetProperty("type", out JsonElement typeElement))
+                                            {
+                                                string itemType = typeElement.GetString();
+                                                
+                                                if (itemType == "text" && item.TryGetProperty("text", out JsonElement textElement))
+                                                {
+                                                    toolResultContent.Add(new TextContent() { Text = textElement.GetString() ?? string.Empty });
+                                                }
+                                                else if (itemType == "image" && 
+                                                         item.TryGetProperty("data", out JsonElement dataElement) &&
+                                                         item.TryGetProperty("mimeType", out JsonElement mimeTypeElement))
+                                                {
+                                                    toolResultContent.Add(new ImageContent()
+                                                    {
+                                                        Source = new()
+                                                        {
+                                                            Data = dataElement.GetString() ?? string.Empty,
+                                                            MediaType = mimeTypeElement.GetString() ?? "image/png"
+                                                        }
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        // Not a content array, serialize as string
+                                        toolResultContent.Add(new TextContent() { Text = jsonElement.ToString() });
+                                    }
+                                }
+                                else if (frc.Result != null)
+                                {
+                                    // Fallback for other types
+                                    toolResultContent.Add(new TextContent() { Text = frc.Result.ToString() ?? string.Empty });
+                                }
+                                else
+                                {
+                                    // Null result
+                                    toolResultContent.Add(new TextContent() { Text = string.Empty });
+                                }
+                                
                                 currentMessage.Content.Add(new ToolResultContent()
                                 {
                                     ToolUseId = frc.CallId,
-                                    Content = new List<ContentBase>() { new TextContent () { Text = frc.Result?.ToString() ?? string.Empty } },
+                                    Content = toolResultContent,
                                     IsError = frc.Exception is not null,
                                 });
                                 break;


### PR DESCRIPTION
When tools return multiple content parts they end up in the `object? Result` property of the MEAI tool result content. This wasn't properly mapped back to Anthropic SDK types, causing image tool results to turn into base64 data - which means they're no longer treated as images/vision content by the model and API. It also makes a difference in terms of text content whether it's correctly mapped to API types (additional tokens and the structured format can sometimes confuse the model).

I tested this with the `getTinyImageTool` from the `server-everything` MCP server. It returns [text,image,text] content parts, so it's a good test case to see if the payload is preserved across mapping between MEAI and Anthropic.SDK types.

I noticed that IsError is always lost. I will try to fix that in a subsequent PR.