### PR TITLE
fix: ProcessSchemaNode crashes on nullable types (JsonArray)

### DIFF
--- a/Anthropic.SDK/Messaging/ChatClientHelper.cs
+++ b/Anthropic.SDK/Messaging/ChatClientHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -460,9 +460,12 @@ namespace Anthropic.SDK.Messaging
             if (node is not JsonObject obj)
                 return;
 
-            // If this is an object type, ensure additionalProperties is false
+            // If this is an object type, ensure additionalProperties is false.
+            // Check for JsonValue first: nullable types produce "type": ["string", "null"] (a JsonArray),
+            // and calling GetValue<string>() on a JsonArray throws InvalidOperationException.
             if (obj.TryGetPropertyValue("type", out var typeNode) &&
-                typeNode?.GetValue<string>() == "object")
+                typeNode is JsonValue typeValue &&
+                typeValue.GetValue<string>() == "object")
             {
                 obj["additionalProperties"] = false;
             }


### PR DESCRIPTION
## Problem

`ProcessSchemaNode` in `ChatClientHelper.cs` calls `typeNode?.GetValue<string>()` without checking if `typeNode` is a `JsonValue`. 

When a JSON schema contains nullable types like `"type": ["string", "null"]`, the `type` node is a `JsonArray`, not a `JsonValue`. Calling `GetValue<string>()` on a `JsonArray` throws `InvalidOperationException: The node must be of type 'JsonValue'`.

This affects both `EnsureAdditionalPropertiesFalse` (ResponseFormat path) and `ProcessToolSchema` (strict tools path).

## Fix

Check that `typeNode` is a `JsonValue` before calling `GetValue<string>()`:

```csharp
// Before (crashes on JsonArray):
if (obj.TryGetPropertyValue("type", out var typeNode) &&
    typeNode?.GetValue<string>() == "object")

// After:
if (obj.TryGetPropertyValue("type", out var typeNode) &&
    typeNode is JsonValue typeValue &&
    typeValue.GetValue<string>() == "object")
```

## Tests

Added 3 unit tests in `StructuredOutputTests.cs`:

- `ChatClientHelper_WithNullableTypeInSchema_DoesNotThrow` - schema with `"type": ["string", "null"]`
- `ChatClientHelper_WithNullableNestedObjectInSchema_DoesNotThrow` - nested objects with nullable properties
- `ChatClientHelper_WithStrictToolsAndNullableType_DoesNotThrow` - strict tools with nullable function parameters

All 19 existing + new tests pass.