### PR TITLE
fix: MEAI 10.4.1 compatibility for HostedMcpServerTool

### DIFF
--- a/Anthropic.SDK/Anthropic.SDK.csproj
+++ b/Anthropic.SDK/Anthropic.SDK.csproj
@@ -36,13 +36,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.4.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.4" />
   </ItemGroup>
 	<ItemGroup>
 		<None Include="..\README.md">

--- a/Anthropic.SDK/Messaging/ChatClientHelper.cs
+++ b/Anthropic.SDK/Messaging/ChatClientHelper.cs
@@ -126,10 +126,17 @@ namespace Anthropic.SDK.Messaging
 
                                 if (mcpt.AllowedTools is not null)
                                 {
-                                    mcpServer.ToolConfiguration.AllowedTools.AddRange(mcpt.AllowedTools);
+                                    (mcpServer.ToolConfiguration ??= new MCPToolConfiguration()).AllowedTools.AddRange(mcpt.AllowedTools);
                                 }
 
-                                mcpServer.AuthorizationToken = mcpt.AuthorizationToken;
+                                // In MEAI 10.4.1+, AuthorizationToken was removed from HostedMcpServerTool.
+                                // Authentication is now passed via the Headers dictionary.
+                                if (mcpt.Headers != null && mcpt.Headers.TryGetValue("Authorization", out var authHeader) && authHeader != null)
+                                {
+                                    mcpServer.AuthorizationToken = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                                        ? authHeader.Substring("Bearer ".Length)
+                                        : authHeader;
+                                }
 
                                 (parameters.MCPServers ??= []).Add(mcpServer);
                                 break;


### PR DESCRIPTION
## Summary

Fixes #197

Resolves a `MissingMethodException` at runtime when using `Anthropic.SDK` 5.10.0 with stable `Microsoft.Extensions.AI` 10.4.1+.

### Root Cause

`ChatClientHelper.cs` accessed `HostedMcpServerTool.AuthorizationToken`, which existed in MEAI 10.3.0-preview but was **removed** in stable 10.4.1. Authentication is now passed via the `Headers` dictionary instead.

Additionally, `mcpServer.ToolConfiguration` was never initialized before calling `.AllowedTools.AddRange(...)`, causing a `NullReferenceException` if `AllowedTools` was set.

### Changes

**`Anthropic.SDK.csproj`**
- `Microsoft.Extensions.AI.Abstractions`: `10.3.0` → `10.4.1`
- `Microsoft.Bcl.AsyncInterfaces`: `10.0.3` → `10.0.4` (transitive requirement of MEAI 10.4.1)
- `System.Text.Json` (netstandard2.0 only): `10.0.3` → `10.0.4` (transitive requirement)

**`ChatClientHelper.cs`**
- Replace `mcpt.AuthorizationToken` with extraction from `mcpt.Headers["Authorization"]`, stripping `Bearer ` prefix if present
- Guard `mcpServer.ToolConfiguration` with null-coalescing initializer before `AllowedTools.AddRange`

### Migration for HostedMcpServerTool users

```csharp
// Before (MEAI preview)
new HostedMcpServerTool("server", "https://...") { AuthorizationToken = "mytoken" }

// After (MEAI 10.4.1 stable)
new HostedMcpServerTool("server", "https://...")
{
    Headers = new Dictionary<string, string> { ["Authorization"] = "Bearer mytoken" }
}
```